### PR TITLE
Support multiple versions of factory_bot with appraisal for testing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,18 +19,11 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-${{ matrix.ruby }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.ruby }}-gems-
       - name: Run the tests and lint the code
         env:
           COVERAGE: true
         run: |
           gem install bundler
-          bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
-          bundle exec rake spec
-          bundle exec rubocop
+          bundle exec appraisal install
+          bundle exec appraisal rake check

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+gemfiles/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,8 @@ require:
 AllCops:
   NewCops: enable
   TargetRubyVersion: 2.6
+  Exclude:
+    - gemfiles/*.gemfile
 
 Layout/HashAlignment:
   EnforcedColonStyle: table

--- a/Appraisals
+++ b/Appraisals
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+appraise "factory_bot-5" do
+  gem "factory_bot", "~> 5.0"
+end
+
+appraise "factory_bot-6" do
+  gem "factory_bot", "~> 6.0"
+end

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0 — Unreleased.
+
+* Support multiple versions of factory_bot.
+
 ## 0.1.0 — November 5th, 2021
 
 * Initial release.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     factory_manager (0.1.0)
-      factory_bot (~> 6.0)
+      factory_bot (>= 5)
 
 GEM
   remote: https://rubygems.org/
@@ -19,6 +19,10 @@ GEM
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
     ansi (1.5.0)
+    appraisal (2.4.1)
+      bundler
+      rake
+      thor (>= 0.14.0)
     ast (2.4.2)
     concurrent-ruby (1.1.9)
     diff-lcs (1.4.4)
@@ -80,6 +84,7 @@ GEM
     sqlite3 (1.4.2)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
+    thor (1.1.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
@@ -91,6 +96,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (= 6.1.4.1)
+  appraisal (= 2.4.1)
   factory_manager!
   rake (= 13.0.6)
   rspec (= 3.10.0)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -25,14 +25,15 @@ git clone https://github.com/tristandunn/factory_manager
 Install the dependencies and setup the database.
 
 ```sh
-bin/setup
+bundle install
+bundle exec appraisal install
 ```
 
 You can verify everything is installed and setup correctly by running the
 `check` Rake task to run the tests and lint the code.
 
 ```sh
-bundle exec rake check
+bundle exec appraisal rake check
 ```
 
 ## Issues and Feature Requests

--- a/factory_manager.gemspec
+++ b/factory_manager.gemspec
@@ -17,9 +17,10 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.6"
 
-  s.add_dependency "factory_bot", "~> 6.0"
+  s.add_dependency "factory_bot", ">= 5"
 
   s.add_development_dependency "activerecord",        "6.1.4.1"
+  s.add_development_dependency "appraisal",           "2.4.1"
   s.add_development_dependency "rake",                "13.0.6"
   s.add_development_dependency "rspec",               "3.10.0"
   s.add_development_dependency "rubocop",             "1.22.3"


### PR DESCRIPTION
Fixes #2.

Adds supports for `~> 5` of `factory_bot` using [`appraisal`](https://github.com/thoughtbot/appraisal) to test multiple versions.

## Checklist

- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] I have updated any relevant documentation.
- [x] I have verified my changes by running `bundle exec rake check`.
