### PR TITLE
Add support for aliased and nested factories.

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.2.0 — Unreleased.
+## 0.2.0 — Unreleased
 
+* Add support for aliased and nested factories.
 * Support multiple versions of factory_bot.
 
 ## 0.1.0 — November 5th, 2021

--- a/README.markdown
+++ b/README.markdown
@@ -11,7 +11,8 @@ allowing deeply nested records to be created easily.
 ## Example
 
 Create a forum, with a single category, a first post for the category, an
-administrative user, and one-hundred approved posts by the administrator.
+administrative user, and one-hundred approved posts by the administrator. Then
+create a featured category with a single post.
 
 ```ruby
 result = FactoryManager.create do
@@ -22,6 +23,10 @@ result = FactoryManager.create do
       self.administrator = administrator = user(:admin)
 
       post(100, :approved, user: administrator)
+    end
+
+    featured_category do
+      post
     end
   end
 end
@@ -68,6 +73,10 @@ FactoryBot.defined do
     trait :approved do
       approved { true }
     end
+
+    factory :featured_category do
+      featured { true }
+    end
   end
 end
 ```
@@ -100,6 +109,13 @@ result = FactoryManager.create do
       # the +post.user+ association to the administrator user created above and
       # the +post.category+ to the news category created above.
       post(100, :approved, user: administrator)
+
+      # Create a +Category+ using the +featured_category+ factory, aliasing the
+      # factory as a +category+ to correctly associated child records, such as
+      # the single post created in it.
+      featured_category(alias: :category) do
+        post
+      end
     end
   end
 end

--- a/lib/factory_manager.rb
+++ b/lib/factory_manager.rb
@@ -1,136 +1,24 @@
 # frozen_string_literal: true
 
 # A factory manager of factory bots.
-class FactoryManager
-  # Initializes a new factory.
-  def initialize(strategy:)
-    @locals = {}
-    @results = {}
-    @scopes = {}
-    @strategy = strategy
-  end
+module FactoryManager
+  autoload :Generator, "factory_manager/generator"
 
-  # Initializes and builds a new factory.
+  # Initializes and builds a new build generator.
   #
-  # @yield Invokes the block to build the factory.
+  # @yield Invokes the block to build the generator.
   def self.build(&block)
-    instance = new(strategy: :build)
-    instance.generate(&block)
+    Generator
+      .new(strategy: :build)
+      .generate(&block)
   end
 
-  # Initializes and creates a new factory.
+  # Initializes and creates a new create generator.
   #
-  # @yield Invokes the block to create the factory.
+  # @yield Invokes the block to create the generator.
   def self.create(&block)
-    instance = new(strategy: :create)
-    instance.generate(&block)
-  end
-
-  # Generate the factory.
-  #
-  # @yield Invokes the block to generate the factory.
-  # @return [OpenStruct] An object containing the record results.
-  def generate(&block)
-    instance_eval(&block)
-
-    OpenStruct.new(@locals)
-  end
-
-  private
-
-  # Add a record to a new or existing scope.
-  #
-  # @param [ActiveRecord::Base] The record to add to the scope.
-  # @param [Symbol] scope The name of the scope.
-  # @return [ActiveRecord::Base] The record.
-  def _add_to_scope(record, scope:)
-    @scopes[scope] ||= []
-    @scopes[scope] << record
-
-    yield
-
-    @scopes[scope].pop
-  end
-
-  # Assign a local variable.
-  #
-  # @param [Symbol] method The method name for the local.
-  # @param [*] value The value of the local.
-  def _assign_local(method, value)
-    @locals[method.to_s.tr("=", "")] = value
-  end
-
-  # Determine if a name is an assignment method.
-  #
-  # @param [Symbol] name The assignment method name.
-  # @return [Boolean] Whether or not the name is an assignment method.
-  def _assignment_method?(name)
-    name.to_s.end_with?("=")
-  end
-
-  # Find the associations for a specific factory.
-  #
-  # @param [String] name The factory name.
-  # @return [Hash] The associations for the factory.
-  def _associations_for(name)
-    @scopes
-      .slice(*_factory_attributes(name))
-      .transform_values(&:last)
-  end
-
-  # Determine all attribute names for a factory.
-  #
-  # @param [String] name The factory name.
-  # @return [Array] The attributes for the factory.
-  def _factory_attributes(name)
-    @_factory_attributes ||= {}
-    @_factory_attributes[name] ||= FactoryBot.factories.find(name).definition.attributes.names
-  end
-
-  # Generate a factory record with associations and custom attributes.
-  #
-  # @param [String] name The factory name.
-  # @param [Hash] arguments The factory arguments.
-  # @return [ActiveRecord::Base] The built factory record.
-  def _generate_factory(name, *arguments)
-    arguments.push(
-      _associations_for(name).merge(arguments.extract_options!)
-    )
-
-    method = arguments.first.is_a?(Integer) ? "#{@strategy}_list" : @strategy
-
-    FactoryBot.public_send(method, name, *arguments)
-  end
-
-  # Generate a factory record for the missing method.
-  #
-  # @param [Symbol] method The name of the method.
-  # @param [Hash] arguments The factory arguments.
-  # @return [ActiveRecord::Base] The built factory record.
-  def method_missing(method, *arguments, &block)
-    super unless respond_to_missing?(method)
-
-    if _assignment_method?(method)
-      _assign_local(method, arguments.first)
-    else
-      record = _generate_factory(method, *arguments)
-
-      _add_to_scope(record, scope: method) do
-        generate(&block) if block
-      end
-
-      record
-    end
-  end
-
-  # Determine if a factory exists for the missing method, or if a local
-  # variable is being assigned.
-  #
-  # @param [Symbol] method The name of the method.
-  # @return [Boolean] Whether or not the factory exists.
-  def respond_to_missing?(method)
-    !FactoryBot.factories.find(method).nil?
-  rescue KeyError
-    _assignment_method?(method)
+    Generator
+      .new(strategy: :create)
+      .generate(&block)
   end
 end

--- a/lib/factory_manager/generator.rb
+++ b/lib/factory_manager/generator.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+module FactoryManager
+  # The factory manager generator.
+  class Generator
+    # Initializes a new factory generator.
+    def initialize(strategy:)
+      @associations = {}
+      @locals = {}
+      @results = {}
+      @strategy = strategy
+    end
+
+    # Generates the factory.
+    #
+    # @yield Instance evaluates the block to generate the factory.
+    # @return [OpenStruct] An object containing the generator results.
+    def generate(&block)
+      instance_eval(&block)
+
+      OpenStruct.new(@locals)
+    end
+
+    private
+
+    # Adds a record to a new or existing association.
+    #
+    # @param [ActiveRecord::Base] The record to add to the associations.
+    # @param [Symbol] name The name of the association.
+    # @return [ActiveRecord::Base] The record.
+    def _add_association(record, name:)
+      _factory_names(name).each do |factory_name|
+        @associations[factory_name] ||= []
+        @associations[factory_name] << record
+      end
+
+      yield
+
+      _factory_names(name).each do |factory_name|
+        @associations[factory_name].pop
+      end
+
+      record
+    end
+
+    # Assigns a local variable.
+    #
+    # @param [Symbol] method The method name for the local.
+    # @param [*] value The value of the local.
+    def _assign_local(method, value)
+      @locals[method.to_s.tr("=", "")] = value
+    end
+
+    # Determines if the method is an assignment method.
+    #
+    # @param [Symbol] method The assignment method name.
+    # @return [Boolean] Whether or not the method is an assignment method.
+    def _assignment_method?(method)
+      method.to_s.end_with?("=")
+    end
+
+    # Finds the matching associations for a specific factory.
+    #
+    # @param [String] name The factory name.
+    # @return [Hash] The current associations for the factory.
+    def _associations_for(name)
+      @associations
+        .slice(*_factory_attributes(name))
+        .transform_values(&:last)
+    end
+
+    # Retrieves all attribute names for a factory.
+    #
+    # @param [String] name The factory name.
+    # @return [Array] The attribute names for the factory.
+    def _factory_attributes(name)
+      @_factory_attributes ||= {}
+      @_factory_attributes[name] ||= FactoryBot.factories.find(name).definition.attributes.names
+    end
+
+    # Returns the factory names up the nested tree.
+    #
+    # @param [String] name The factory name.
+    # @return [Array] The names the factory can be referred to as.
+    def _factory_names(name)
+      factory = FactoryBot.factories.find(name)
+      parent  = factory.__send__(:parent)
+      names   = factory.names
+
+      while parent.respond_to?(:names)
+        names.push(*parent.names)
+
+        parent = parent.__send__(:parent)
+      end
+
+      names
+    end
+
+    # Generates a factory record with associations and custom attributes.
+    #
+    # @param [String] name The factory name.
+    # @param [Hash] arguments The factory arguments.
+    # @return [ActiveRecord::Base] The built or created factory record.
+    def _generate_factory(name, *arguments)
+      arguments.push(
+        _associations_for(name).merge(arguments.extract_options!)
+      )
+
+      method = arguments.first.is_a?(Integer) ? "#{@strategy}_list" : @strategy
+
+      FactoryBot.public_send(method, name, *arguments)
+    end
+
+    # Attempts to generate a factory record for the missing method.
+    #
+    # Also handles assignments for the resulting generator object.
+    #
+    # @param [Symbol] method The name of the method.
+    # @param [Hash] arguments The factory arguments.
+    # @return [ActiveRecord::Base] The built factory record.
+    def method_missing(method, *arguments, &block)
+      super unless respond_to_missing?(method)
+
+      if _assignment_method?(method)
+        _assign_local(method, arguments.first)
+      else
+        record = _generate_factory(method, *arguments)
+
+        _add_association(record, name: method) do
+          generate(&block) if block
+        end
+      end
+    end
+
+    # Determines if a factory exists for the missing method, or if a variable
+    # is being assigned.
+    #
+    # @param [Symbol] method The name of the method.
+    # @return [Boolean] Whether or not the factory exists.
+    def respond_to_missing?(method)
+      !FactoryBot.factories.find(method).nil?
+    rescue KeyError
+      _assignment_method?(method)
+    end
+  end
+end

--- a/spec/lib/factory_manager/generator_spec.rb
+++ b/spec/lib/factory_manager/generator_spec.rb
@@ -1,0 +1,253 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe FactoryManager::Generator do
+  describe "#generate, with a build strategy" do
+    context "with a valid factory" do
+      it "builds a record" do
+        result = build do
+          self.user = user
+        end
+
+        expect(result.user).to be_a(User)
+      end
+
+      it "does not persist the record" do
+        result = build do
+          self.user = user
+        end
+
+        expect(result.user).not_to be_persisted
+      end
+    end
+
+    context "with a factory trait" do
+      it "builds a record using the trait" do
+        result = build do
+          self.user = user(:admin, name: "Admin")
+        end
+
+        expect(result.user).to have_attributes(name: "Admin", admin: true)
+      end
+    end
+
+    context "with a number" do
+      it "builds multiple records" do
+        result = build do
+          self.users = user(2, :admin, name: "Admin")
+        end
+
+        expect(result.users).to contain_exactly(
+          an_object_having_attributes(name: "Admin", admin: true),
+          an_object_having_attributes(name: "Admin", admin: true)
+        )
+      end
+    end
+
+    context "with custom attributes" do
+      it "forwards the custom attributes to the factory" do
+        result = build do
+          self.user = user(name: "Tester")
+        end
+
+        expect(result.user).to have_attributes(name: "Tester")
+      end
+    end
+
+    context "with associations" do
+      it "allows nesting of associated records" do
+        result = build do
+          self.user = user do
+            self.post = post(title: "User's Post")
+          end
+        end
+
+        expect(result.post).to have_attributes(
+          user:  result.user,
+          title: "User's Post"
+        )
+      end
+
+      it "allows multiple level nesting of associated records" do
+        result = build do
+          self.user_1 = user do
+            self.user_2 = user do
+              self.post = post(title: "User's Post")
+            end
+          end
+        end
+
+        expect(result).to have_attributes(
+          user_1: an_instance_of(User),
+          user_2: an_instance_of(User),
+          post:   an_object_having_attributes(
+            user:  result.user_2,
+            title: "User's Post"
+          )
+        )
+      end
+    end
+
+    context "with an invalid factory" do
+      it "raises a no method error" do
+        expect do
+          build { fake }
+        end.to raise_error(NoMethodError)
+      end
+    end
+
+    def build(&block)
+      described_class.new(strategy: :build).generate(&block)
+    end
+  end
+
+  describe "#generate, with a create strategy" do
+    context "with a valid factory" do
+      it "creates a record" do
+        create do
+          user
+        end
+
+        expect(User.count).to eq(1)
+      end
+    end
+
+    context "with a factory trait" do
+      it "creates a record using the trait" do
+        create do
+          user(:admin, name: "Admin")
+        end
+
+        expect(User.all).to contain_exactly(
+          an_object_having_attributes(name: "Admin", admin: true)
+        )
+      end
+    end
+
+    context "with a number" do
+      it "creates multiple records" do
+        create do
+          user(2, :admin, name: "Admin")
+        end
+
+        expect(User.all).to contain_exactly(
+          an_object_having_attributes(name: "Admin", admin: true),
+          an_object_having_attributes(name: "Admin", admin: true)
+        )
+      end
+    end
+
+    context "with custom attributes" do
+      it "forwards the custom attributes to the factory" do
+        create do
+          user(name: "Tester")
+        end
+
+        expect(User.all).to contain_exactly(
+          an_object_having_attributes(name: "Tester")
+        )
+      end
+    end
+
+    context "with associations" do
+      it "allows nesting of associated records" do
+        create do
+          user do
+            post(title: "User's Post")
+          end
+        end
+
+        expect(User.all).to contain_exactly(
+          an_object_having_attributes(
+            posts: [an_object_having_attributes(title: "User's Post")]
+          )
+        )
+      end
+
+      it "allows multiple level nesting of associated records" do
+        create do
+          user do
+            user do
+              post(title: "User's Post")
+            end
+          end
+        end
+
+        expect(User.all).to contain_exactly(
+          an_object_having_attributes(
+            posts: []
+          ),
+          an_object_having_attributes(
+            posts: [an_object_having_attributes(title: "User's Post")]
+          )
+        )
+      end
+
+      it "supports nested factories" do
+        create do
+          admin_user do
+            post(title: "Admin's Post")
+          end
+        end
+
+        expect(User.all).to contain_exactly(
+          an_object_having_attributes(
+            admin: true,
+            posts: [an_object_having_attributes(title: "Admin's Post")]
+          )
+        )
+      end
+
+      it "supports factory aliases" do
+        create do
+          super_admin do
+            post(title: "Admin's Post")
+          end
+        end
+
+        expect(User.all).to contain_exactly(
+          an_object_having_attributes(
+            admin: true,
+            posts: [an_object_having_attributes(title: "Admin's Post")]
+          )
+        )
+      end
+    end
+
+    context "with local variables" do
+      it "returns an object with local variable assignments" do
+        result = create do
+          user do
+            self.admin = admin = user(:admin)
+
+            self.user = user(name: "Local User") do
+              self.post = post(title: "User's Post")
+            end
+
+            self.announcement = post(user: admin)
+          end
+        end
+
+        expect(result).to have_attributes(
+          admin:        an_object_having_attributes(admin: true),
+          announcement: an_object_having_attributes(user: result.admin),
+          post:         an_object_having_attributes(title: "User's Post"),
+          user:         an_object_having_attributes(name: "Local User")
+        )
+      end
+    end
+
+    context "with an invalid factory" do
+      it "raises a no method error" do
+        expect do
+          create { fake }
+        end.to raise_error(NoMethodError)
+      end
+    end
+
+    def create(&block)
+      described_class.new(strategy: :create).generate(&block)
+    end
+  end
+end

--- a/spec/support/database/factories.rb
+++ b/spec/support/database/factories.rb
@@ -17,6 +17,12 @@ RSpec.configure do |config|
         trait :admin do
           admin { true }
         end
+
+        factory :admin_user, aliases: [:super_admin] do
+          sequence(:name) { |n| "Admin ##{n}" }
+
+          admin { true }
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #1.

Aliased factories are supported by storing records in the association cache by `FactoryBot::Factory#names` instead of only the method missing name. Nested factories are supported by using the private `FactoryBot::Factory.parent` API to traverse through the tree.

## Example

With the following factories:

```ruby
FactoryBot.define do
  factory :post do
    user
  end

  factory :user do
    factory :admin_user, aliases: [:super_admin] do
      admin { true }
    end
  end
end
```

The `post.user` association will be set correctly using the following manager:

```ruby
FactoryManager.create do
  admin_user do
    post
  end

  super_admin do
    post
  end
end
```

## Checklist

- [x] I have read the [CONTRIBUTING](/docs/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] I have updated any relevant documentation.
- [x] I have verified my changes by running `bundle exec rake check`.
